### PR TITLE
[Refactor] handler 거쳐서 탈퇴 로직 변경

### DIFF
--- a/BE/src/main/java/com/d201/fundingift/_common/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -185,6 +185,15 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
             // 친구 목록 전부 삭제
             friendService.deleteAllFriendsByConsumerId(consumerId);
+            log.info("Deleted all friends for consumerId: {}", consumerId);
+
+            // 4. Consumer 논리 삭제
+            try {
+                consumerService.withdrawConsumer(consumerId); // Consumer 논리 삭제 메서드 호출
+                log.info("Consumer has been logically deleted: {}", consumerId);
+            } catch (Exception e) {
+                log.error("Error logically deleting consumer for consumerId: {}: {}", consumerId, e.getMessage());
+            }
 
             log.info("Completed unlink process for consumerId: {}", consumerId);
 

--- a/BE/src/main/java/com/d201/fundingift/consumer/controller/ConsumerController.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/controller/ConsumerController.java
@@ -94,24 +94,6 @@ public class ConsumerController {
         return ResponseUtils.ok(SuccessType.LOGOUT_SUCCESS);
     }
 
-    @Operation(summary = "회원탈퇴",
-            description = "현재 사용자가 자신의 계정을 탈퇴합니다. 모든 관련 데이터는 논리삭제 처리됩니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",
-                    description = "성공",
-                    useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "400",
-                    description = "유효하지 않은 요청",
-                    useReturnTypeSchema = true)
-    })
-    @PostMapping("/withdraw")
-    public SuccessResponse<Void> withdrawConsumer() {
-        log.info("ConsumerController.withdrawConsumer");
-        Long consumerId = securityUtil.getConsumerId();
-        consumerService.withdrawConsumer(consumerId);
-        return ResponseUtils.ok(SuccessType.WITHDRAW_CONSUMER_SUCCESS);
-    }
-
     @GetMapping("/in-progress-funding")
     @Operation(summary = "진행 중인 펀딩 확인", description = "사용자가 진행 중이거나 참여 중인 펀딩이 있는지 확인합니다.")
     public SuccessResponse<Boolean> isConsumerInProgressOrAttendanceFunding() {

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -182,6 +182,4 @@ public class ConsumerService {
         // 4. 논리 삭제 (JPA에서 삭제 처리하면 @SQLDelete가 작동)
         consumerRepository.delete(consumer); // @SQLDelete에 정의된 쿼리가 실행됨
     }
-
-
 }


### PR DESCRIPTION
회원탈퇴 관련
- 컨트롤러에서 요청이 아니라 핸들러에서 서비스 요청하도록 변경
- 프론트 돌려서 로컬 테스트 완료

이슈) 핸들러에 동작 로직이 다 들어가 있어서 단일 책임 원칙 X

리팩토링 방향
	1.	핸들러의 역할 단순화:
	•	OAuth2AuthenticationSuccessHandler는 인증 성공 후 요청을 적절한 서비스에 위임하고, 결과에 따라 리다이렉션만 담당하도록 설계합니다.
	2.	서비스 레이어로 책임 분리:
	•	로그인/회원가입/회원탈퇴 로직을 서비스 클래스로 분리합니다.
	•	각 책임은 명확히 독립된 클래스 또는 메서드로 분리됩니다.
	3.	에러 처리 및 로깅 통일:
	•	예외 처리 로직을 서비스에서 담당하여 핸들러의 복잡도를 줄입니다.