### PR TITLE
[Refactor] 상품 로직 리팩토링

### DIFF
--- a/BE/src/main/java/com/d201/fundingift/funding/repository/FundingRepository.java
+++ b/BE/src/main/java/com/d201/fundingift/funding/repository/FundingRepository.java
@@ -53,12 +53,6 @@ public interface FundingRepository extends JpaRepository<Funding, Long> {
             "AND f.consumer.id = :consumerId AND f.isPrivate = false AND f.deletedAt IS NULL")
     List<Funding> findAllByConsumerIdAndIsPrivateAndDeletedAtIsNull(@Param("consumerId") Long consuerId, @Param("year") Integer year, @Param("month") Integer month);
 
-    @Query("select p FROM Funding f right join f.product p " +
-            "where p.status = 'ACTIVE' and p.deletedAt is null " +
-            "group by p order by count(f) desc")
-    Slice<Product> findProductSliceOrderByFundingCount(Pageable pageable);
-
-
     @Query("SELECT f FROM Funding f WHERE f.consumer.id IN :consumerIds and f.fundingStatus = 'IN_PROGRESS' AND f.deletedAt IS NULL")
     Slice<Funding> findAllByConsumerIdsAndFundingStatusAndDeletedAtIsNull(@Param("consumerIds") List<Long> consumerIds, Pageable pageable);
 

--- a/BE/src/main/java/com/d201/fundingift/product/entity/ProductCategory.java
+++ b/BE/src/main/java/com/d201/fundingift/product/entity/ProductCategory.java
@@ -30,8 +30,4 @@ public class ProductCategory {
 
     @Column(nullable = true)
     private LocalDateTime deletedAt;
-
-    @OneToMany(mappedBy = "productCategory", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Product> products = new ArrayList<>();
-
 }

--- a/BE/src/main/java/com/d201/fundingift/product/repository/ProductOptionRepository.java
+++ b/BE/src/main/java/com/d201/fundingift/product/repository/ProductOptionRepository.java
@@ -21,6 +21,5 @@ public interface ProductOptionRepository extends JpaRepository<ProductOption, Lo
 
     @Query("select po from ProductOption po " +
             "where po.product = :product and po.status <> 'INACTIVE' and po.deletedAt is null")
-    List<ProductOption> findAllByProduct(@Param("product") Product product);
-
+    List<ProductOption> findByProductAndStatusIsNotInactive(@Param("product") Product product);
 }

--- a/BE/src/main/java/com/d201/fundingift/product/repository/ProductRepository.java
+++ b/BE/src/main/java/com/d201/fundingift/product/repository/ProductRepository.java
@@ -15,27 +15,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "where p.id = :productId and p.status = 'ACTIVE' and p.deletedAt is null")
     Optional<Product> findById(@Param("productId") Long productId);
 
-    // 전체 목록
     @Query("select p from Product p " +
-            "where p.status = 'ACTIVE' and p.deletedAt is null")
-    Slice<Product> findAllSlice(Pageable pageable);
-
-    // 전체 목록 + 검색어
-    @Query("select p from Product p " +
-            "where (p.name like %:keyword% or p.description like %:keyword% or p.productCategory.name like %:keyword%) " +
-            "and p.status = 'ACTIVE' and p.deletedAt is null")
-    Slice<Product> findAllSliceByKeyword(@Param("keyword") String keyword, Pageable pageable);
-
-    // 카테고리 별 목록
-    @Query("select p from Product p " +
-            "where p.productCategory.id = :categoryId " +
-            "and p.status = 'ACTIVE' and p.deletedAt is null")
-    Slice<Product> findAllSliceByCategoryId(@Param("categoryId") Integer productCategoryId, Pageable pageable);
-
-    // 카테고리 별 목록 + 검색어
-    @Query("select p from Product p " +
-            "where p.productCategory.id = :categoryId " +
-            "and (p.name like %:keyword% or p.description like %:keyword% or p.productCategory.name like %:keyword%) " +
+            "where (:categoryId is null or p.productCategory.id = :categoryId) " +
+            "and (:keyword is null or p.name like %:keyword% or p.description like %:keyword% or p.productCategory.name like %:keyword%) " +
             "and p.status = 'ACTIVE' and p.deletedAt is null")
     Slice<Product> findAllSliceByCategoryIdAndKeyword(@Param("categoryId") Integer productCategoryId, @Param("keyword") String keyword, Pageable pageable);
 

--- a/BE/src/main/java/com/d201/fundingift/product/repository/ProductRepository.java
+++ b/BE/src/main/java/com/d201/fundingift/product/repository/ProductRepository.java
@@ -21,4 +21,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "and p.status = 'ACTIVE' and p.deletedAt is null")
     Slice<Product> findAllSliceByCategoryIdAndKeyword(@Param("categoryId") Integer productCategoryId, @Param("keyword") String keyword, Pageable pageable);
 
+    @Query("select p from Product p " +
+            "left join Funding f on f.product = p " +
+            "group by p " +
+            "order by count(f) desc")
+    Slice<Product> findAllSliceOrderByFundingCount(Pageable pageable);
 }

--- a/BE/src/main/java/com/d201/fundingift/product/service/ProductService.java
+++ b/BE/src/main/java/com/d201/fundingift/product/service/ProductService.java
@@ -12,7 +12,6 @@ import com.d201.fundingift.product.entity.Product;
 import com.d201.fundingift.product.repository.ProductCategoryRepository;
 import com.d201.fundingift.product.repository.ProductOptionRepository;
 import com.d201.fundingift.product.repository.ProductRepository;
-import com.d201.fundingift.wishlist.entity.Wishlist;
 import com.d201.fundingift.wishlist.repository.WishlistRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,41 +40,47 @@ public class ProductService {
     private final FundingRepository fundingRepository;
     private final SecurityUtil securityUtil;
 
-    // 카테고리 리스트 조회
+    /** 상품 카테고리 목록 조회 **/
     public List<GetProductCategoryResponse> getCategories() {
         return productCategoryRepository.findAllByDeletedAtIsNull()
                 .stream().map(GetProductCategoryResponse::from)
                 .collect(Collectors.toList());
     }
 
-    // 상품 리스트 조회
+    /** 상품 목록 조회 **/
     public SliceList<GetProductResponse> getProducts(Integer categoryId, String keyword, Integer page, Integer size, Integer sort) {
-        // 페이징 객체
-        Pageable pageable = PageRequest.of(page, size, getSort(sort));
-
-        /**
-         * 전체 목록 조회
-         */
-        if (categoryId == null) {
-            // 키워드 X
-            if (keyword == null) {
-                return getProductResponseSliceList(productRepository.findAllSlice(pageable));
-            }
-            // 키워드 O
-            return getProductResponseSliceList(productRepository.findAllSliceByKeyword(keyword, pageable));
+        if (categoryId != null) {
+            validateCategoryId(categoryId);
         }
 
-        /**
-         * 카테고리 별 목록 조회
-         */
-        validateCategoryId(categoryId); // 카테고리 유효성 검사
+        Slice<Product> products = productRepository.findAllSliceByCategoryIdAndKeyword(categoryId, keyword, PageRequest.of(page, size, getSort(sort)));
+        return getProductResponseSliceList(products);
+    }
 
-        // 키워드 X
-        if (keyword == null) {
-            return getProductResponseSliceList(productRepository.findAllSliceByCategoryId(categoryId, pageable));
+    private Sort getSort(Integer sort) {
+        Sort defaultSort = Sort.by("id").descending();
+        if (sort == 0) { // 기본 (최신 순)
+            return defaultSort;
         }
-        // 키워드 O
-        return getProductResponseSliceList(productRepository.findAllSliceByCategoryIdAndKeyword(categoryId, keyword, pageable));
+        if (sort == 1) { // 리뷰 많은 순
+            return Sort.by("reviewCnt").descending().and(defaultSort);
+        }
+        if (sort == 2) { // 평점 높은 순
+            return Sort.by("reviewAvg").descending().and(defaultSort);
+        }
+        if (sort == 3) { // 가격 높은 순
+            return Sort.by("price").descending().and(defaultSort);
+        }
+        if (sort == 4) { // 가격 낮은 순
+            return Sort.by("price").ascending().and(defaultSort);
+        }
+        throw new CustomException(SORT_NOT_FOUND);
+    }
+
+    private SliceList<GetProductResponse> getProductResponseSliceList(Slice<Product> products) {
+        return SliceList.from(products.stream().map(GetProductResponse::from).collect(Collectors.toList()),
+                products.getPageable(),
+                products.hasNext());
     }
 
     public SliceList<GetProductResponse> getProductsRank(Integer page, Integer size) {
@@ -93,38 +98,6 @@ public class ProductService {
         boolean isWishlist = getIsWishlist(productId);
         // 반환
         return GetProductDetailResponse.from(product, options, isWishlist);
-    }
-
-    // 정렬 객체
-    private Sort getSort(Integer sort) {
-        // 기본 순 (최신 순)
-        if (sort == 0) {
-            return Sort.by("id").descending();
-        }
-        // 리뷰 많은 순
-        if (sort == 1) {
-            return Sort.by("reviewCnt").descending();
-        }
-        // 평점 높은 순
-        if (sort == 2) {
-            return Sort.by("reviewAvg").descending();
-        }
-        // 가격 높은 순
-        if (sort == 3) {
-            return Sort.by("price").descending();
-        }
-        // 가격 낮은 순
-        if (sort == 4) {
-            return Sort.by("price").ascending();
-        }
-        // 예외
-        throw new CustomException(SORT_NOT_FOUND);
-    }
-
-    private SliceList<GetProductResponse> getProductResponseSliceList(Slice<Product> products) {
-        return SliceList.from(products.stream().map(GetProductResponse::from).collect(Collectors.toList()),
-                products.getPageable(),
-                products.hasNext());
     }
 
     private List<GetProductOptionResponse> getOptions(Product product) {

--- a/BE/src/main/java/com/d201/fundingift/product/service/ProductService.java
+++ b/BE/src/main/java/com/d201/fundingift/product/service/ProductService.java
@@ -3,7 +3,6 @@ package com.d201.fundingift.product.service;
 import com.d201.fundingift._common.exception.CustomException;
 import com.d201.fundingift._common.response.SliceList;
 import com.d201.fundingift._common.util.SecurityUtil;
-import com.d201.fundingift.funding.repository.FundingRepository;
 import com.d201.fundingift.product.dto.response.GetProductCategoryResponse;
 import com.d201.fundingift.product.dto.response.GetProductDetailResponse;
 import com.d201.fundingift.product.dto.response.GetProductOptionResponse;
@@ -16,7 +15,6 @@ import com.d201.fundingift.wishlist.repository.WishlistRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -37,7 +35,6 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final ProductOptionRepository productOptionRepository;
     private final WishlistRepository wishlistRepository;
-    private final FundingRepository fundingRepository;
     private final SecurityUtil securityUtil;
 
     /** 상품 카테고리 목록 조회 **/
@@ -55,6 +52,12 @@ public class ProductService {
 
         Slice<Product> products = productRepository.findAllSliceByCategoryIdAndKeyword(categoryId, keyword, PageRequest.of(page, size, getSort(sort)));
         return getProductResponseSliceList(products);
+    }
+
+    private void validateCategoryId(Integer categoryId) {
+        if (!productCategoryRepository.existsByIdAndDeletedAtIsNull(categoryId)) {
+            throw new CustomException(PRODUCT_CATEGORY_NOT_FOUND);
+        }
     }
 
     private Sort getSort(Integer sort) {
@@ -89,7 +92,7 @@ public class ProductService {
         return getProductResponseSliceList(products);
     }
 
-    // 상품 상세 조회
+    /** 상품 상세 조회 **/
     public GetProductDetailResponse getProductDetail(Long productId) {
         // 상품
         Product product = findByProductId(productId);
@@ -102,7 +105,7 @@ public class ProductService {
     }
 
     private List<GetProductOptionResponse> getOptions(Product product) {
-        return productOptionRepository.findAllByProduct(product)
+        return productOptionRepository.findByProductAndStatusIsNotInactive(product)
                 .stream().map(GetProductOptionResponse::from)
                 .collect(Collectors.toList());
     }
@@ -121,11 +124,4 @@ public class ProductService {
 
         return wishlistRepository.findByConsumerIdAndProductId(consumerId, productId).isPresent();
     }
-
-    private void validateCategoryId(Integer categoryId) {
-        if (!productCategoryRepository.existsByIdAndDeletedAtIsNull(categoryId)) {
-            throw new CustomException(PRODUCT_CATEGORY_NOT_FOUND);
-        }
-    }
-
 }

--- a/BE/src/main/java/com/d201/fundingift/product/service/ProductService.java
+++ b/BE/src/main/java/com/d201/fundingift/product/service/ProductService.java
@@ -83,9 +83,10 @@ public class ProductService {
                 products.hasNext());
     }
 
+    /** 추천 상품 목록 조회 **/
     public SliceList<GetProductResponse> getProductsRank(Integer page, Integer size) {
-        Pageable pageable = PageRequest.of(page, size);
-        return getProductResponseSliceList(fundingRepository.findProductSliceOrderByFundingCount(pageable));
+        Slice<Product> products = productRepository.findAllSliceOrderByFundingCount(PageRequest.of(page, size));
+        return getProductResponseSliceList(products);
     }
 
     // 상품 상세 조회


### PR DESCRIPTION
## 반영 브랜치

- refactor-product -> main

<br/>

## 🔎 작업 내용

- 불필요한 양방향 매핑 제거 
  - `ProductCategory`의 `List<Product>` 제거
  - `Product`의 `List<ProductOption>`도 제거하려고 하였으나, 쓰이고 있는 로직이 있어 @kdozlo 에게 문의한 결과 펀딩 리팩토링 하면서 제거하셨다고 하여 그대로 두었습니다.
- 상품 목록 조회, 추천 상품 목록 조회 쿼리 수정
- 상품 목록 조회 시 기본 정렬 조건 추가
- 주석 및 코드 스타일(?) 일부 변경

<br/>

## 🚩 참고 사항

- 큰 수정 사항은 없고, 백엔드 로직만 약간 수정했습니다.
- 위시리스트 리팩토링 후 상품 상세 조회 로직 수정할 가능성 있습니다.

<br/>
