### PR TITLE
[Feat] 로그인 트랜잭션 최적화 및 Refresh Token 로직 추가

### DIFF
--- a/BE/src/main/java/com/d201/fundingift/_common/config/SecurityConfig.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.d201.fundingift._common.oauth2.handler.OAuth2AuthenticationFailureHan
 import com.d201.fundingift._common.oauth2.handler.OAuth2AuthenticationSuccessHandler;
 import com.d201.fundingift._common.oauth2.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -15,6 +16,11 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
@@ -29,11 +35,14 @@ public class SecurityConfig {
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
 
+    @Value("${base-url}")
+    private String baseUrl;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // CORS 설정 (기본 설정 사용)
-//                .cors(Customizer.withDefaults())
+                // CORS 설정 적용: corsConfigurationSource() 메서드에서 정의한 설정 사용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 // CSRF 보호 기능 비활성화
                 .csrf(AbstractHttpConfigurer::disable)
                 // HTTP 기본 인증 비활성화
@@ -66,6 +75,26 @@ public class SecurityConfig {
         http.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        // 허용할 출처: 로컬 및 배포 환경 URL
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", baseUrl));
+        // 허용할 HTTP 메서드
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
+        // 허용할 헤더
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Cache-Control"));
+        // 쿠키 등 자격 증명 포함 여부
+        configuration.setAllowCredentials(true);
+        // preflight 요청의 캐싱 시간 (초 단위)
+        configuration.setMaxAge(3000L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        // 모든 경로에 대해 위의 CORS 설정 적용
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }
 

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -14,6 +14,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+
+import static com.d201.fundingift._common.oauth2.util.CookieUtils.addCookie;
+
 @RequiredArgsConstructor
 @Component
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
@@ -115,12 +118,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER);
 
             // 5. 응답 쿠키에 새로운 리프레쉬 토큰을 설정합니다.
-            Cookie refreshTokenCookie = new Cookie("Refresh-Token", newRefreshToken);
-            refreshTokenCookie.setHttpOnly(true); // 자바스크립트에서 접근 불가
-            refreshTokenCookie.setSecure(true);   // HTTPS 환경에서만 전송 (프로덕션 환경에서는 true)
-            refreshTokenCookie.setPath("/");        // 전체 도메인에서 접근 가능하도록 설정
-            // refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60); // 필요시 만료 시간 설정 (예: 7일)
-            response.addCookie(refreshTokenCookie);
+            addCookie(response, "Refresh-Token", newRefreshToken, jwtUtil.getRefreshTokenExpiry());
         } else {
             logger.info("JwtAuthorizationFilter: ❌ 리프레쉬 토큰이 유효하지 않음 → 401 반환 (재로그인 필요)");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token is Invalid"); // 401 반환

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -81,15 +81,20 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(refreshToken) && jwtUtil.validateRefreshToken(refreshToken)) {
             logger.info("JwtAuthorizationFilter: 유효한 리프레쉬 토큰이 확인되었습니다. 새로운 액세스 토큰을 발급합니다.");
 
-            // 새로운 액세스 토큰을 발급합니다.
+            // 새로운 액세스 토큰과 리프레쉬 토큰을 발급합니다.
             String newAccessToken = jwtUtil.createAccessToken(userId);
+            String newRefreshToken = jwtUtil.createRefreshToken(userId);
+
+            // Redis에 새로운 리프레쉬 토큰을 저장하여 기존 토큰을 덮어씌웁니다.
+            redisTemplate.opsForValue().set(refreshTokenKey, newRefreshToken);
 
             // SecurityContext를 새로운 액세스 토큰 기반으로 업데이트합니다.
             setAuthenticationFromToken(newAccessToken);
 
-            // 응답 헤더에 새로운 액세스 토큰을 추가하여 클라이언트에게 전달합니다.
+            // 응답 헤더에 새로운 액세스 토큰과 리프레쉬 토큰을 추가하여 클라이언트에게 전달합니다.
             response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newAccessToken);
-            response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER);
+            response.setHeader("Refresh-Token", newRefreshToken);
+            response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER + ", Refresh-Token");
         } else {
             logger.info("JwtAuthorizationFilter: 유효한 리프레쉬 토큰을 찾지 못했습니다.");
         }

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -26,38 +26,49 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String path = request.getRequestURI();
 
-        // /login-callback 경로에 대한 필터링 제외 처리
+        // 특정 경로(login-callback) 필터링 제외
         if ("/login-callback".equals(path)) {
             filterChain.doFilter(request, response);
             return;
         }
 
         String token = resolveToken(request);
-//        boolean isTokenRefreshed = false;
+        boolean isTokenRefreshed = false;
 
         logger.info("JwtAuthorizationFilter: Filtering request");
 
         if (StringUtils.hasText(token)) {
             logger.info("JwtAuthorizationFilter: Token found: " + token);
             if (jwtUtil.validateAccessToken(token)) {
+                // ✅ Access Token이 유효하면 인증 정보 설정
                 logger.info("JwtAuthorizationFilter: Valid access token");
                 Authentication authentication = jwtUtil.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } else if (jwtUtil.isTokenExpired(token)) {
-                logger.info("JwtAuthorizationFilter: Token is expired");
-//                String userId = jwtUtil.extractUserIdFromExpiredToken(token);
-//                logger.info("JwtAuthorizationFilter: Extracted userId: " + userId);
-//                String refreshToken = redisTemplate.opsForValue().get("refreshToken:" + userId);
-//                if (refreshToken != null && jwtUtil.validateRefreshToken(refreshToken)) {
-//                    logger.info("JwtAuthorizationFilter: Valid refresh token");
-//                    String newAccessToken = jwtUtil.createAccessToken(userId);
-//                    SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(newAccessToken));
-//                    response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newAccessToken);
-//                    isTokenRefreshed = true;
-//                    logger.info("JwtAuthorizationFilter: Access token refreshed");
-//                } else {
-//                    logger.info("JwtAuthorizationFilter: Refresh token is invalid or missing");
-//                }
+                // ✅ Access Token 만료된 경우 Refresh Token 확인 후 재발급
+                logger.info("JwtAuthorizationFilter: Access token expired, checking refresh token...");
+
+                String userId = jwtUtil.extractUserIdFromExpiredToken(token);
+                Long consumerId = Long.parseLong(userId);
+
+                // 🪙 Redis에서 Refresh Token 가져오기
+                String refreshToken = redisTemplate.opsForValue().get("refreshToken:" + consumerId);
+
+                if (refreshToken != null && jwtUtil.validateRefreshToken(refreshToken)) {
+                    logger.info("JwtAuthorizationFilter: Valid refresh token found, issuing new access token.");
+
+                    // 🪙 새로운 Access Token 발급
+                    String newAccessToken = jwtUtil.createAccessToken(userId);
+
+                    // 🪙 SecurityContext 업데이트
+                    SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(newAccessToken));
+
+                    // 🪙 새로운 Access Token을 응답 헤더에 추가
+                    response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newAccessToken);
+                    isTokenRefreshed = true;
+                } else {
+                    logger.info("JwtAuthorizationFilter: No valid refresh token found.");
+                }
             } else {
                 logger.info("JwtAuthorizationFilter: Access token is invalid");
             }
@@ -68,13 +79,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
         logger.info("JwtAuthorizationFilter: Request processed");
 
-        // Todo : 리프레쉬 로직 작동 안 함. 신경 안 쓰는 중..
+        // Todo : 리프레쉬 로직 작성, 정상 작동 하는 지 확인 필요
 
-        // 토큰이 새롭게 발급되었다면, 해당 정보를 클라이언트에게 전달
-//        if (isTokenRefreshed) {
-//            response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER);
-//            logger.info("JwtAuthorizationFilter: New token added to response header");
-//        }
+        // ✅ 새로운 Access Token이 발급된 경우, 클라이언트가 헤더에서 받을 수 있도록 설정
+        if (isTokenRefreshed) {
+            response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER);
+            logger.info("JwtAuthorizationFilter: New token added to response header");
+        }
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -64,7 +64,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         setAuthenticationFromToken(token);
     }
 
-    private void processExpiredAccessToken(String expiredToken, HttpServletResponse response) {
+    private void processExpiredAccessToken(String expiredToken, HttpServletRequest request, HttpServletResponse response) {
         logger.info("JwtAuthorizationFilter: 액세스 토큰이 만료되었습니다. 리프레쉬 토큰 확인을 진행합니다.");
 
         // 만료된 액세스 토큰에서 사용자 식별자(userId)를 추출합니다.
@@ -73,12 +73,20 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
         // Todo : 클라이언트가 리프레쉬 토큰을 가지고 있다가 액세스 토큰이 만료되면 같이 보내줘야함. 현재는 레디스의 리프레쉬 토큰만 확인해서 발급(X)
 
+        // 클라이언트가 요청 헤더에 보낸 리프레쉬 토큰을 추출합니다.
+        String providedRefreshToken = request.getHeader("Refresh-Token");
+        if (!StringUtils.hasText(providedRefreshToken)) {
+            logger.info("JwtAuthorizationFilter: 클라이언트에서 리프레쉬 토큰을 제공하지 않았습니다.");
+            return;
+        }
+
         // Redis에서 해당 사용자의 리프레쉬 토큰을 조회합니다.
         String refreshTokenKey = REFRESH_TOKEN_KEY_PREFIX + consumerId;
-        String refreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
+        String storedRefreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
 
-        // 리프레쉬 토큰이 존재하며 유효한지 확인합니다.
-        if (StringUtils.hasText(refreshToken) && jwtUtil.validateRefreshToken(refreshToken)) {
+        // 클라이언트가 제공한 토큰과 Redis에 저장된 토큰이 일치하며, 토큰이 유효한지 확인합니다.
+        if (StringUtils.hasText(storedRefreshToken) &&providedRefreshToken.equals(storedRefreshToken) &&
+                jwtUtil.validateRefreshToken(providedRefreshToken)) {
             logger.info("JwtAuthorizationFilter: 유효한 리프레쉬 토큰이 확인되었습니다. 새로운 액세스 토큰을 발급합니다.");
 
             // 새로운 액세스 토큰과 리프레쉬 토큰을 발급합니다.

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -18,72 +18,80 @@ import java.io.IOException;
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String LOGIN_CALLBACK_PATH = "/login-callback";
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
     private static final String BEARER_PREFIX = "Bearer ";
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate; // RedisTemplate 추가
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
+        return LOGIN_CALLBACK_PATH.equals(path);
+    }
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            // 1. 요청 헤더에서 토큰을 추출합니다.
+            String token = resolveToken(request);
 
-        // 특정 경로(login-callback) 필터링 제외
-        if ("/login-callback".equals(path)) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        String token = resolveToken(request);
-        boolean isTokenRefreshed = false;
-
-        logger.info("JwtAuthorizationFilter: Filtering request");
-
-        if (StringUtils.hasText(token)) {
-            logger.info("JwtAuthorizationFilter: Token found: " + token);
-            if (jwtUtil.validateAccessToken(token)) {
-                // ✅ Access Token이 유효하면 인증 정보 설정
-                logger.info("JwtAuthorizationFilter: Valid access token");
-                setAuthenticationFromToken(token);
-            } else if (jwtUtil.isTokenExpired(token)) {
-                // ✅ Access Token 만료된 경우 Refresh Token 확인 후 재발급
-                logger.info("JwtAuthorizationFilter: Access token expired, checking refresh token...");
-
-                String userId = jwtUtil.extractUserIdFromExpiredToken(token);
-                Long consumerId = Long.parseLong(userId);
-
-                // 🪙 Redis에서 Refresh Token 가져오기
-                String refreshToken = redisTemplate.opsForValue().get("refreshToken:" + consumerId);
-
-                if (refreshToken != null && jwtUtil.validateRefreshToken(refreshToken)) {
-                    logger.info("JwtAuthorizationFilter: Valid refresh token found, issuing new access token.");
-
-                    // 🪙 새로운 Access Token 발급
-                    String newAccessToken = jwtUtil.createAccessToken(userId);
-
-                    // 🪙 SecurityContext 업데이트
-                    setAuthenticationFromToken(newAccessToken);
-
-                    // 🪙 새로운 Access Token을 응답 헤더에 추가
-                    response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newAccessToken);
-                    isTokenRefreshed = true;
-                } else {
-                    logger.info("JwtAuthorizationFilter: No valid refresh token found.");
-                }
-            } else {
-                logger.info("JwtAuthorizationFilter: Access token is invalid");
+            // 2. 토큰이 존재하지 않는 경우
+            if (!StringUtils.hasText(token)) {
+                logger.info("JwtAuthorizationFilter: 요청에서 토큰을 찾을 수 없습니다.");
             }
-        } else {
-            logger.info("JwtAuthorizationFilter: No token found in the request");
+            // 3. 액세스 토큰이 유효한 경우
+            else if (jwtUtil.validateAccessToken(token)) {
+                processValidAccessToken(token);
+            }
+            // 4. 액세스 토큰이 만료된 경우 (리프레쉬 토큰 확인)
+            else if (jwtUtil.isTokenExpired(token)) {
+                processExpiredAccessToken(token, response);
+            }
+            // 5. 그 외 (액세스 토큰이 유효하지 않은 경우)
+            else {
+                logger.info("JwtAuthorizationFilter: 액세스 토큰이 유효하지 않습니다.");
+            }
+        } catch (Exception e){
+            logger.error("JwtAuthorizationFilter: SecurityContext에 사용자 인증 정보를 설정하는 중 오류 발생", e);
         }
 
         filterChain.doFilter(request, response);
-        logger.info("JwtAuthorizationFilter: Request processed");
+    }
 
-        // Todo : 리프레쉬 로직 작성, 정상 작동 하는 지 확인 필요
+    private void processValidAccessToken(String token) {
+        logger.info("JwtAuthorizationFilter: 유효한 액세스 토큰이 확인되었습니다.");
+        // 토큰 기반으로 인증 정보를 생성하여 SecurityContext에 저장합니다.
+        setAuthenticationFromToken(token);
+    }
 
-        // ✅ 새로운 Access Token이 발급된 경우, 클라이언트가 헤더에서 받을 수 있도록 설정
-        if (isTokenRefreshed) {
+    private void processExpiredAccessToken(String expiredToken, HttpServletResponse response) {
+        logger.info("JwtAuthorizationFilter: 액세스 토큰이 만료되었습니다. 리프레쉬 토큰 확인을 진행합니다.");
+
+        // 만료된 액세스 토큰에서 사용자 식별자(userId)를 추출합니다.
+        String userId = jwtUtil.extractUserIdFromExpiredToken(expiredToken);
+        Long consumerId = Long.parseLong(userId);
+
+        // Todo : 클라이언트가 리프레쉬 토큰을 가지고 있다가 액세스 토큰이 만료되면 같이 보내줘야함. 현재는 레디스의 리프레쉬 토큰만 확인해서 발급(X)
+
+        // Redis에서 해당 사용자의 리프레쉬 토큰을 조회합니다.
+        String refreshTokenKey = REFRESH_TOKEN_KEY_PREFIX + consumerId;
+        String refreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
+
+        // 리프레쉬 토큰이 존재하며 유효한지 확인합니다.
+        if (StringUtils.hasText(refreshToken) && jwtUtil.validateRefreshToken(refreshToken)) {
+            logger.info("JwtAuthorizationFilter: 유효한 리프레쉬 토큰이 확인되었습니다. 새로운 액세스 토큰을 발급합니다.");
+
+            // 새로운 액세스 토큰을 발급합니다.
+            String newAccessToken = jwtUtil.createAccessToken(userId);
+
+            // SecurityContext를 새로운 액세스 토큰 기반으로 업데이트합니다.
+            setAuthenticationFromToken(newAccessToken);
+
+            // 응답 헤더에 새로운 액세스 토큰을 추가하여 클라이언트에게 전달합니다.
+            response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newAccessToken);
             response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER);
-            logger.info("JwtAuthorizationFilter: New token added to response header");
+        } else {
+            logger.info("JwtAuthorizationFilter: 유효한 리프레쉬 토큰을 찾지 못했습니다.");
         }
     }
 

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -45,7 +45,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             }
             // 4. 액세스 토큰이 만료된 경우 (리프레쉬 토큰 확인)
             else if (jwtUtil.isTokenExpired(token)) {
-                processExpiredAccessToken(token, response);
+                processExpiredAccessToken(token, request, response);
             }
             // 5. 그 외 (액세스 토큰이 유효하지 않은 경우)
             else {
@@ -64,19 +64,20 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         setAuthenticationFromToken(token);
     }
 
-    private void processExpiredAccessToken(String expiredToken, HttpServletRequest request, HttpServletResponse response) {
+    private void processExpiredAccessToken(String expiredToken, HttpServletRequest request, HttpServletResponse response) throws IOException {
         logger.info("JwtAuthorizationFilter: 액세스 토큰이 만료되었습니다. 리프레쉬 토큰 확인을 진행합니다.");
 
         // 만료된 액세스 토큰에서 사용자 식별자(userId)를 추출합니다.
         String userId = jwtUtil.extractUserIdFromExpiredToken(expiredToken);
         Long consumerId = Long.parseLong(userId);
 
-        // Todo : 클라이언트가 리프레쉬 토큰을 가지고 있다가 액세스 토큰이 만료되면 같이 보내줘야함. 현재는 레디스의 리프레쉬 토큰만 확인해서 발급(X)
+        // Todo : 클라이언트가 리프레쉬 토큰을 가지고 있다가 액세스 토큰이 만료되면 같이 보내줘야함.
 
         // 클라이언트가 요청 헤더에 보낸 리프레쉬 토큰을 추출합니다.
         String providedRefreshToken = request.getHeader("Refresh-Token");
         if (!StringUtils.hasText(providedRefreshToken)) {
-            logger.info("JwtAuthorizationFilter: 클라이언트에서 리프레쉬 토큰을 제공하지 않았습니다.");
+            logger.info("JwtAuthorizationFilter: 리프레쉬 토큰이 없음 ❌ → 401 반환 (재로그인 필요)");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token is required"); // 401 반환
             return;
         }
 
@@ -104,7 +105,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             response.setHeader("Refresh-Token", newRefreshToken);
             response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER + ", Refresh-Token");
         } else {
-            logger.info("JwtAuthorizationFilter: 유효한 리프레쉬 토큰을 찾지 못했습니다.");
+            logger.info("JwtAuthorizationFilter: ❌ 리프레쉬 토큰이 유효하지 않음 → 401 반환 (재로그인 필요)");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token is Invalid"); // 401 반환
         }
     }
 

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -42,8 +42,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             if (jwtUtil.validateAccessToken(token)) {
                 // ✅ Access Token이 유효하면 인증 정보 설정
                 logger.info("JwtAuthorizationFilter: Valid access token");
-                Authentication authentication = jwtUtil.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                setAuthenticationFromToken(token);
             } else if (jwtUtil.isTokenExpired(token)) {
                 // ✅ Access Token 만료된 경우 Refresh Token 확인 후 재발급
                 logger.info("JwtAuthorizationFilter: Access token expired, checking refresh token...");
@@ -61,7 +60,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                     String newAccessToken = jwtUtil.createAccessToken(userId);
 
                     // 🪙 SecurityContext 업데이트
-                    SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(newAccessToken));
+                    setAuthenticationFromToken(newAccessToken);
 
                     // 🪙 새로운 Access Token을 응답 헤더에 추가
                     response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newAccessToken);
@@ -94,5 +93,10 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             return token.substring(BEARER_PREFIX.length());
         }
         return null;
+    }
+
+    public void setAuthenticationFromToken(String token) {
+        Authentication authentication = jwtUtil.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -2,6 +2,7 @@ package com.d201.fundingift._common.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -65,27 +66,36 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     }
 
     private void processExpiredAccessToken(String expiredToken, HttpServletRequest request, HttpServletResponse response) throws IOException {
-        logger.info("JwtAuthorizationFilter: 액세스 토큰이 만료되었습니다. 리프레쉬 토큰 확인을 진행합니다.");
+        logger.info("JwtAuthorizationFilter: 액세스 토큰이 만료되었습니다. 쿠키에 저장된 리프레쉬 토큰을 확인합니다.");
 
         // 만료된 액세스 토큰에서 사용자 식별자(userId)를 추출합니다.
         String userId = jwtUtil.extractUserIdFromExpiredToken(expiredToken);
         Long consumerId = Long.parseLong(userId);
 
-        // Todo : 클라이언트가 리프레쉬 토큰을 가지고 있다가 액세스 토큰이 만료되면 같이 보내줘야함.
+        // Todo : 클라이언트에 쿠키에 있는 리프레쉬 토큰을 가져오기.
 
-        // 클라이언트가 요청 헤더에 보낸 리프레쉬 토큰을 추출합니다.
-        String providedRefreshToken = request.getHeader("Refresh-Token");
+        // 1. 쿠키에서 리프레쉬 토큰을 추출합니다.
+        String providedRefreshToken = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("Refresh-Token".equals(cookie.getName())) {
+                    providedRefreshToken = cookie.getValue();
+                    break;
+                }
+            }
+        }
         if (!StringUtils.hasText(providedRefreshToken)) {
-            logger.info("JwtAuthorizationFilter: 리프레쉬 토큰이 없음 ❌ → 401 반환 (재로그인 필요)");
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token is required"); // 401 반환
+            logger.info("JwtAuthorizationFilter: 쿠키에 리프레쉬 토큰이 없음 ❌ → 401 반환");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token is required");
             return;
         }
 
-        // Redis에서 해당 사용자의 리프레쉬 토큰을 조회합니다.
+        // 2. Redis에서 해당 사용자의 리프레쉬 토큰을 조회합니다.
         String refreshTokenKey = REFRESH_TOKEN_KEY_PREFIX + consumerId;
         String storedRefreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
 
-        // 클라이언트가 제공한 토큰과 Redis에 저장된 토큰이 일치하며, 토큰이 유효한지 확인합니다.
+        // 3. 쿠키에서 제공한 토큰과 Redis에 저장된 토큰이 일치하며, 토큰이 유효한지 확인합니다.
         if (StringUtils.hasText(storedRefreshToken) &&providedRefreshToken.equals(storedRefreshToken) &&
                 jwtUtil.validateRefreshToken(providedRefreshToken)) {
             logger.info("JwtAuthorizationFilter: 유효한 리프레쉬 토큰이 확인되었습니다. 새로운 액세스 토큰을 발급합니다.");
@@ -94,16 +104,23 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             String newAccessToken = jwtUtil.createAccessToken(userId);
             String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
-            // Redis에 새로운 리프레쉬 토큰을 저장하여 기존 토큰을 덮어씌웁니다.
+            // Redis에 새로운 리프레쉬 토큰 저장 (기존 토큰 덮어씌우기)
             redisTemplate.opsForValue().set(refreshTokenKey, newRefreshToken);
 
             // SecurityContext를 새로운 액세스 토큰 기반으로 업데이트합니다.
             setAuthenticationFromToken(newAccessToken);
 
-            // 응답 헤더에 새로운 액세스 토큰과 리프레쉬 토큰을 추가하여 클라이언트에게 전달합니다.
+            // 응답 헤더에 새로운 액세스 토큰을 추가합니다.
             response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + newAccessToken);
-            response.setHeader("Refresh-Token", newRefreshToken);
-            response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER + ", Refresh-Token");
+            response.addHeader("Access-Control-Expose-Headers", AUTHORIZATION_HEADER);
+
+            // 5. 응답 쿠키에 새로운 리프레쉬 토큰을 설정합니다.
+            Cookie refreshTokenCookie = new Cookie("Refresh-Token", newRefreshToken);
+            refreshTokenCookie.setHttpOnly(true); // 자바스크립트에서 접근 불가
+            refreshTokenCookie.setSecure(true);   // HTTPS 환경에서만 전송 (프로덕션 환경에서는 true)
+            refreshTokenCookie.setPath("/");        // 전체 도메인에서 접근 가능하도록 설정
+            // refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60); // 필요시 만료 시간 설정 (예: 7일)
+            response.addCookie(refreshTokenCookie);
         } else {
             logger.info("JwtAuthorizationFilter: ❌ 리프레쉬 토큰이 유효하지 않음 → 401 반환 (재로그인 필요)");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token is Invalid"); // 401 반환

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtAuthorizationFilter.java
@@ -26,7 +26,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
     private static final String BEARER_PREFIX = "Bearer ";
     private final JwtUtil jwtUtil;
-    private final RedisTemplate<String, String> redisTemplate; // RedisTemplate 추가
+    private final RedisJwtRepository redisJwtRepository;
+    //private final RedisTemplate<String, String> redisTemplate; // RedisTemplate 추가
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
@@ -95,8 +96,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         }
 
         // 2. Redis에서 해당 사용자의 리프레쉬 토큰을 조회합니다.
-        String refreshTokenKey = REFRESH_TOKEN_KEY_PREFIX + consumerId;
-        String storedRefreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
+        //String refreshTokenKey = REFRESH_TOKEN_KEY_PREFIX + consumerId;
+        String storedRefreshToken = redisJwtRepository.getRefreshToken(consumerId);
 
         // 3. 쿠키에서 제공한 토큰과 Redis에 저장된 토큰이 일치하며, 토큰이 유효한지 확인합니다.
         if (StringUtils.hasText(storedRefreshToken) &&providedRefreshToken.equals(storedRefreshToken) &&
@@ -108,7 +109,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             String newRefreshToken = jwtUtil.createRefreshToken(userId);
 
             // Redis에 새로운 리프레쉬 토큰 저장 (기존 토큰 덮어씌우기)
-            redisTemplate.opsForValue().set(refreshTokenKey, newRefreshToken);
+            redisJwtRepository.saveRefreshToken(consumerId,newRefreshToken);
 
             // SecurityContext를 새로운 액세스 토큰 기반으로 업데이트합니다.
             setAuthenticationFromToken(newAccessToken);

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtRepository.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtRepository.java
@@ -1,15 +1,12 @@
 package com.d201.fundingift._common.jwt;
 
 public interface JwtRepository {
-    void saveAccessToken(Long consumerId, String accessToken);
     void saveRefreshToken(Long consumerId, String refreshToken);
     void saveKakaoAccessToken(Long consumerId, String kakaoAccessToken);
 
-    String getAccessToken(Long consumerId);
     String getRefreshToken(Long consumerId);
     String getKakaoAccessToken(Long consumerId);
 
-    void deleteAccessToken(Long consumerId);
     void deleteRefreshToken(Long consumerId);
     void deleteKakaoAccessToken(Long consumerId);
 }

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
@@ -25,8 +25,8 @@ import java.util.Date;
 public class JwtUtil {
 
     //private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 30; // 30min
-    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 3000; // 3000분
-    private static final long REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 60 * 24 * 7; // 7일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 10; // 10초
+    private static final long REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60; // 1분
 //    private final RedisTemplate redisTemplate;
 
     

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
@@ -25,11 +25,11 @@ import java.util.Date;
 public class JwtUtil {
 
     //private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 30; // 30min
-    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 30; // 30초
+    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60; // 30초
     private static final long REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 60; // 60분
 //    private final RedisTemplate redisTemplate;
 
-    
+
     @Value("${jwt.secret}")
     private String secret;
     private Key key;

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
@@ -149,4 +149,12 @@ public class JwtUtil {
             return null;
         }
     }
+
+    public int getAccessTokenExpiry() {
+        return (int) (ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS / 1000); // 초 단위 반환
+    }
+
+    public int getRefreshTokenExpiry() {
+        return (int) (REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS / 1000); // 초 단위 반환
+    }
 }

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
@@ -25,7 +25,7 @@ import java.util.Date;
 public class JwtUtil {
 
     //private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 30; // 30min
-    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60; // 30초
+    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 30; // 30초
     private static final long REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 60; // 60분
 //    private final RedisTemplate redisTemplate;
 

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
@@ -25,8 +25,8 @@ import java.util.Date;
 public class JwtUtil {
 
     //private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 30; // 30min
-    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 10; // 10초
-    private static final long REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60; // 1분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 10; // 10분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 60; // 60분
 //    private final RedisTemplate redisTemplate;
 
     

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/JwtUtil.java
@@ -25,7 +25,7 @@ import java.util.Date;
 public class JwtUtil {
 
     //private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 30; // 30min
-    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 10; // 10분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 30; // 30초
     private static final long REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000 * 60 * 60; // 60분
 //    private final RedisTemplate redisTemplate;
 

--- a/BE/src/main/java/com/d201/fundingift/_common/jwt/RedisJwtRepository.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/jwt/RedisJwtRepository.java
@@ -12,11 +12,6 @@ public class RedisJwtRepository implements JwtRepository {
     private final StringRedisTemplate redisTemplate;
 
     @Override
-    public void saveAccessToken(Long consumerId, String accessToken) {
-        redisTemplate.opsForValue().set("accessToken:" + consumerId, accessToken);
-    }
-
-    @Override
     public void saveRefreshToken(Long consumerId, String refreshToken) {
         redisTemplate.opsForValue().set("refreshToken:" + consumerId, refreshToken);
     }
@@ -27,11 +22,6 @@ public class RedisJwtRepository implements JwtRepository {
     }
 
     @Override
-    public String getAccessToken(Long consumerId) {
-        return (String) redisTemplate.opsForValue().get("accessToken:" + consumerId);
-    }
-
-    @Override
     public String getRefreshToken(Long consumerId) {
         return (String) redisTemplate.opsForValue().get("refreshToken:" + consumerId);
     }
@@ -39,11 +29,6 @@ public class RedisJwtRepository implements JwtRepository {
     @Override
     public String getKakaoAccessToken(Long consumerId) {
         return (String) redisTemplate.opsForValue().get("kakaoAccessToken:" + consumerId);
-    }
-
-    @Override
-    public void deleteAccessToken(Long consumerId) {
-        redisTemplate.delete("accessToken:" + consumerId);
     }
 
     @Override

--- a/BE/src/main/java/com/d201/fundingift/_common/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -84,9 +84,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         // mode에 따라 로그인, 회원가입 또는 회원탈퇴 처리
         switch (mode.toLowerCase()) {
             case "login":
-                return consumerService.handleLoginOrRegister(principal, targetUrl);
+                return consumerService.handleLoginOrRegister(principal, targetUrl, response);
             case "unlink":
-                return consumerService.handleUnlink(principal, targetUrl);
+                return consumerService.handleUnlink(principal, targetUrl, request, response);
             default:
 
                 return UriComponentsBuilder.fromUriString(targetUrl)

--- a/BE/src/main/java/com/d201/fundingift/consumer/controller/ConsumerController.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/controller/ConsumerController.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -87,9 +89,9 @@ public class ConsumerController {
     )
     // 로그아웃
     @PostMapping("/logout")
-    public SuccessResponse<Void> postLogoutUser() {
+    public SuccessResponse<Void> postLogoutUser(HttpServletRequest request, HttpServletResponse response) {
         log.info("ConsumerController.postLogoutUser");
-        consumerService.logoutUser();
+        consumerService.logoutUser(request, response);
         // 로그아웃 성공 응답 반환
         return ResponseUtils.ok(SuccessType.LOGOUT_SUCCESS);
     }

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -135,7 +135,7 @@ public class ConsumerService {
         addCookie(response, "Refresh-Token", refreshToken, jwtUtil.getRefreshTokenExpiry());
 
         // 리다이렉션 URL 생성
-        return buildRedirectUrl(targetUrl, consumerId, "sign-up");
+        return buildRedirectUrl(targetUrl, consumerId,accessToken,  "sign-up");
     }
 
     // 회원가입
@@ -173,7 +173,7 @@ public class ConsumerService {
         // 리프레쉬 토큰은 HTTP 쿠키에 저장
         addCookie(response, "Refresh-Token", newRefreshToken, jwtUtil.getRefreshTokenExpiry());
 
-        return buildRedirectUrl(targetUrl, consumerId, "main");
+        return buildRedirectUrl(targetUrl, consumerId, newAccessToken, "main");
     }
 
     /**
@@ -193,9 +193,10 @@ public class ConsumerService {
     }
 
     // ✅ URL 생성 메서드 분리
-    private String buildRedirectUrl(String targetUrl, Long consumerId, String nextPage) {
+    private String buildRedirectUrl(String targetUrl, Long consumerId, String accessToken, String nextPage) {
         return UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("consumer-id", consumerId)
+                .queryParam("access-token", accessToken)
                 .queryParam("next-page", nextPage)
                 .build().toUriString();
     }

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -154,27 +154,15 @@ public class ConsumerService {
     public String loginUser(OAuth2UserPrincipal principal, Consumer consumer, String targetUrl) {
         Long consumerId = consumer.getId();
 
-        // 프로필 변경이 필요할 때만 update 실행
-        if (isProfileChanged(consumer, principal)) {
-            updateProfile(consumer, principal);
-        }
+        updateProfile(consumer, principal);
 
-        // ✅ 새로운 Access Token 발급 (기존 것 무조건 갱신)
+        // ✅ 새로운 Access Token, Refresh Token 발급
         String newAccessToken = jwtUtil.createAccessToken(consumerId.toString());
-        redisJwtRepository.saveAccessToken(consumerId, newAccessToken);
-        log.info("새로운 Access Token 발급: consumerId={}, accessToken={}", consumerId, newAccessToken);
-
-        // ✅ 기존 Refresh Token 확인
-        String existingRefreshToken = redisJwtRepository.getRefreshToken(consumerId);
-        if (existingRefreshToken != null && jwtUtil.validateRefreshToken(existingRefreshToken)) {
-            log.info("기존 Refresh Token 유지: consumerId={}", consumerId);
-            return buildRedirectUrl(targetUrl, newAccessToken, consumerId);
-        }
-
-        // 🔥 Refresh Token 만료 → 새로 발급
         String newRefreshToken = jwtUtil.createRefreshToken(consumerId.toString());
+
         redisJwtRepository.saveRefreshToken(consumerId, newRefreshToken);
-        log.info("Refresh Token 새로 발급: consumerId={}", consumerId);
+        log.info("새로운 Access 및 Refresh Token 발급: consumerId={}, accessToken={}, refreshToken={}",
+                consumerId, newAccessToken, newRefreshToken);
 
         return buildRedirectUrl(targetUrl, newAccessToken, consumerId);
     }
@@ -228,9 +216,8 @@ public class ConsumerService {
             throw new RuntimeException("Failed to logout from Kakao");
         }
 
-        // 2. 로컬 로그아웃 처리: 토큰 무효화
-        // 레디스에서 해당 사용자의 액세스 토큰 및 리프레시 토큰 및 카카오 액세스 토큰 삭제
-        redisJwtRepository.deleteAccessToken(consumerId);
+        // 2. 로컬 로그아웃 처리 : 토큰 삭제
+        // 레디스에서 해당 사용자의 리프레시 토큰 및 카카오 액세스 토큰 삭제
         redisJwtRepository.deleteRefreshToken(consumerId);
         redisJwtRepository.deleteKakaoAccessToken(consumerId);
     }
@@ -252,7 +239,6 @@ public class ConsumerService {
         oAuth2UserUnlinkManager.unlink(provider, accessToken);
 
         // Redis 토큰 삭제
-        redisJwtRepository.deleteAccessToken(consumerId);
         redisJwtRepository.deleteRefreshToken(consumerId);
         redisJwtRepository.deleteKakaoAccessToken(consumerId);
 

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -38,6 +38,7 @@ import static com.d201.fundingift._common.response.ErrorType.*;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ConsumerService {
 
     private final ConsumerRepository consumerRepository;
@@ -51,25 +52,21 @@ public class ConsumerService {
     private final OAuth2UserUnlinkManager oAuth2UserUnlinkManager;
 
     // socialId로 회원 찾기.
-    @Transactional(readOnly = true)
     public Optional<Consumer> findBySocialId(String socialId) {
         return consumerRepository.findBySocialIdAndDeletedAtIsNull(socialId);
     }
 
-    @Transactional(readOnly = true)
     public Consumer findById(Long id) {
         return consumerRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow((() -> new CustomException(USER_NOT_FOUND)));
     }
 
     // 소비자 ID 유효성 검사
-    @Transactional(readOnly = true)
     public boolean isValidConsumerId(Long consumerId) {
         return consumerRepository.existsByIdAndDeletedAtIsNull(consumerId);
     }
 
     // 내 정보 조회
-    @Transactional(readOnly = true)
     public GetConsumerMyInfoResponse getConsumerMyInfo(Authentication authentication) {
         if (authentication == null || authentication.getPrincipal() == null) {
             throw new CustomException(USER_UNAUTHORIZED);
@@ -88,7 +85,6 @@ public class ConsumerService {
     }
 
     // 소비자 프로필 조회
-    @Transactional(readOnly = true)
     public GetConsumerInfoByIdResponse getConsumerInfoById(Long consumerId) {
         return GetConsumerInfoByIdResponse.from(consumerRepository.findByIdAndDeletedAtIsNull(consumerId)
                 .orElseThrow((() -> new CustomException(USER_NOT_FOUND))));

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -126,11 +126,7 @@ public class ConsumerService {
         friendService.synchronizeFriends(consumerId);
 
         // 리다이렉션 URL 생성
-        return UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("access-token", accessToken)
-                .queryParam("consumer-id", consumerId)
-                .queryParam("next-page", "sign-up")
-                .build().toUriString();
+        return buildRedirectUrl(targetUrl, accessToken, refreshToken, consumerId, "sign-up");
     }
 
     // 회원가입
@@ -164,7 +160,7 @@ public class ConsumerService {
         log.info("새로운 Access 및 Refresh Token 발급: consumerId={}",
                 consumerId);
 
-        return buildRedirectUrl(targetUrl, newAccessToken, consumerId);
+        return buildRedirectUrl(targetUrl, newAccessToken, newRefreshToken, consumerId, "main");
     }
 
     /**
@@ -178,11 +174,12 @@ public class ConsumerService {
     }
 
     // ✅ URL 생성 메서드 분리
-    private String buildRedirectUrl(String targetUrl, String accessToken, Long consumerId) {
+    private String buildRedirectUrl(String targetUrl, String accessToken, String refreshToken, Long consumerId, String nextPage) {
         return UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("access-token", accessToken)
+                .queryParam("refresh-token", refreshToken)
                 .queryParam("consumer-id", consumerId)
-                .queryParam("next-page", "main")
+                .queryParam("next-page", nextPage)
                 .build().toUriString();
     }
 

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -37,7 +37,6 @@ import static com.d201.fundingift._common.response.ErrorType.*;
 
 @Service
 @Slf4j
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ConsumerService {
 
@@ -52,21 +51,25 @@ public class ConsumerService {
     private final OAuth2UserUnlinkManager oAuth2UserUnlinkManager;
 
     // socialId로 회원 찾기.
+    @Transactional(readOnly = true)
     public Optional<Consumer> findBySocialId(String socialId) {
         return consumerRepository.findBySocialIdAndDeletedAtIsNull(socialId);
     }
 
-    private Consumer findById(Long id) {
+    @Transactional(readOnly = true)
+    public Consumer findById(Long id) {
         return consumerRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow((() -> new CustomException(USER_NOT_FOUND)));
     }
 
     // 소비자 ID 유효성 검사
+    @Transactional(readOnly = true)
     public boolean isValidConsumerId(Long consumerId) {
         return consumerRepository.existsByIdAndDeletedAtIsNull(consumerId);
     }
 
     // 내 정보 조회
+    @Transactional(readOnly = true)
     public GetConsumerMyInfoResponse getConsumerMyInfo(Authentication authentication) {
         if (authentication == null || authentication.getPrincipal() == null) {
             throw new CustomException(USER_UNAUTHORIZED);
@@ -85,6 +88,7 @@ public class ConsumerService {
     }
 
     // 소비자 프로필 조회
+    @Transactional(readOnly = true)
     public GetConsumerInfoByIdResponse getConsumerInfoById(Long consumerId) {
         return GetConsumerInfoByIdResponse.from(consumerRepository.findByIdAndDeletedAtIsNull(consumerId)
                 .orElseThrow((() -> new CustomException(USER_NOT_FOUND))));
@@ -282,6 +286,7 @@ public class ConsumerService {
         consumer.updateInfo(putConsumerInfoRequestDto);
     }
 
+    @Transactional(readOnly = true)
     public Boolean isConsumerInProgressOrAttendanceFunding() {
         Long consumerId = Long.valueOf(securityUtil.getConsumer().getId());
         log.info("진행 중이거나 참여 중인 펀딩 확인, 사용자 ID: {}", consumerId);

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -119,7 +119,6 @@ public class ConsumerService {
         // 토큰 생성 및 저장
         String accessToken = jwtUtil.createAccessToken(consumerId.toString());
         String refreshToken = jwtUtil.createRefreshToken(consumerId.toString());
-        redisJwtRepository.saveAccessToken(consumerId, accessToken);
         redisJwtRepository.saveRefreshToken(consumerId, refreshToken);
         redisJwtRepository.saveKakaoAccessToken(consumerId, principal.getUserInfo().getAccessToken());
 

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -163,31 +163,24 @@ public class ConsumerService {
             updateProfile(consumer, principal);
         }
 
-        // ✅ 기존 Access Token 확인 (유효하면 재사용)
-        String existingAccessToken = redisJwtRepository.getAccessToken(consumerId);
-        if (existingAccessToken != null && jwtUtil.validateAccessToken(existingAccessToken)) {
-            log.info("기존 토큰 재사용: consumerId={}, accessToken={}", consumerId, existingAccessToken);
-            return buildRedirectUrl(targetUrl, existingAccessToken, consumerId);
-        }
+        // ✅ 새로운 Access Token 발급 (기존 것 무조건 갱신)
+        String newAccessToken = jwtUtil.createAccessToken(consumerId.toString());
+        redisJwtRepository.saveAccessToken(consumerId, newAccessToken);
+        log.info("새로운 Access Token 발급: consumerId={}, accessToken={}", consumerId, newAccessToken);
 
         // ✅ 기존 Refresh Token 확인
         String existingRefreshToken = redisJwtRepository.getRefreshToken(consumerId);
         if (existingRefreshToken != null && jwtUtil.validateRefreshToken(existingRefreshToken)) {
-            String newAccessToken = jwtUtil.createAccessToken(consumerId.toString());
-            redisJwtRepository.saveAccessToken(consumerId, newAccessToken);
-            log.info("새로운 Access Token 발급: consumerId={}", consumerId);
+            log.info("기존 Refresh Token 유지: consumerId={}", consumerId);
             return buildRedirectUrl(targetUrl, newAccessToken, consumerId);
         }
 
-        // 🔥 Access Token과 Refresh Token 모두 만료 → 새로 발급
-        String accessToken = jwtUtil.createAccessToken(consumerId.toString());
-        String refreshToken = jwtUtil.createRefreshToken(consumerId.toString());
-        redisJwtRepository.saveAccessToken(consumerId, accessToken);
-        redisJwtRepository.saveRefreshToken(consumerId, refreshToken);
-        redisJwtRepository.saveKakaoAccessToken(consumerId, principal.getUserInfo().getAccessToken());
+        // 🔥 Refresh Token 만료 → 새로 발급
+        String newRefreshToken = jwtUtil.createRefreshToken(consumerId.toString());
+        redisJwtRepository.saveRefreshToken(consumerId, newRefreshToken);
+        log.info("Refresh Token 새로 발급: consumerId={}", consumerId);
 
-        log.info("Access Token & Refresh Token 새로 발급: consumerId={}", consumerId);
-        return buildRedirectUrl(targetUrl, accessToken, consumerId);
+        return buildRedirectUrl(targetUrl, newAccessToken, consumerId);
     }
 
     /**

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -18,6 +18,8 @@ import com.d201.fundingift.friend.service.FriendService;
 import com.d201.fundingift.funding.intrastructure.entity.FundingEntity;
 import com.d201.fundingift.funding.domain.status.FundingStatus;
 import com.d201.fundingift.funding.intrastructure.repository.FundingJPARepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -33,6 +35,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.util.List;
 import java.util.Optional;
 
+import static com.d201.fundingift._common.oauth2.util.CookieUtils.addCookie;
+import static com.d201.fundingift._common.oauth2.util.CookieUtils.deleteCookie;
 import static com.d201.fundingift._common.response.ErrorType.*;
 
 @Service
@@ -95,16 +99,16 @@ public class ConsumerService {
      * - 회원 정보가 존재하지 않으면 회원가입 처리
      * - 존재하면 로그인 처리
      */
-    public String handleLoginOrRegister(OAuth2UserPrincipal principal, String targetUrl) {
+    public String handleLoginOrRegister(OAuth2UserPrincipal principal, String targetUrl, HttpServletResponse response) {
         String socialId = principal.getUserInfo().getId();
         Optional<Consumer> consumerOptional = findBySocialId(socialId);
 
         if (consumerOptional.isEmpty()) {
             // 회원가입 처리
-            return registerUser(principal, targetUrl);
+            return registerUser(principal, targetUrl, response);
         } else {
             // 로그인 처리
-            return loginUser(principal, consumerOptional.get(), targetUrl);
+            return loginUser(principal, consumerOptional.get(), targetUrl, response);
         }
     }
 
@@ -112,7 +116,7 @@ public class ConsumerService {
      * 회원가입 처리 로직
      */
     @Transactional
-    public String registerUser(OAuth2UserPrincipal principal, String targetUrl) {
+    public String registerUser(OAuth2UserPrincipal principal, String targetUrl, HttpServletResponse response) {
         Long consumerId = saveOAuth2User(principal);
         log.info("회원가입 완료: consumerId={}", consumerId);
 
@@ -125,8 +129,13 @@ public class ConsumerService {
         // 친구 목록 가져오기
         friendService.synchronizeFriends(consumerId);
 
+        // 액세스 토큰은 응답 헤더에 전달
+        sendTokenResponse(response, accessToken);
+        // 리프레쉬 토큰은 HTTP 쿠키에 저장 (쿠키 유효시간은 초 단위)
+        addCookie(response, "Refresh-Token", refreshToken, jwtUtil.getRefreshTokenExpiry());
+
         // 리다이렉션 URL 생성
-        return buildRedirectUrl(targetUrl, accessToken, refreshToken, consumerId, "sign-up");
+        return buildRedirectUrl(targetUrl, consumerId, "sign-up");
     }
 
     // 회원가입
@@ -146,7 +155,7 @@ public class ConsumerService {
      * 로그인 처리 로직
      */
     @Transactional
-    public String loginUser(OAuth2UserPrincipal principal, Consumer consumer, String targetUrl) {
+    public String loginUser(OAuth2UserPrincipal principal, Consumer consumer, String targetUrl, HttpServletResponse response) {
         Long consumerId = consumer.getId();
 
         updateProfile(consumer, principal);
@@ -157,10 +166,14 @@ public class ConsumerService {
 
         redisJwtRepository.saveRefreshToken(consumerId, newRefreshToken);
         redisJwtRepository.saveKakaoAccessToken(consumerId, principal.getUserInfo().getAccessToken());
-        log.info("새로운 Access 및 Refresh Token 발급: consumerId={}",
-                consumerId);
+        log.info("새로운 Access 및 Refresh Token 발급: consumerId={}", consumerId);
 
-        return buildRedirectUrl(targetUrl, newAccessToken, newRefreshToken, consumerId, "main");
+        // 액세스 토큰은 응답 헤더에 전달
+        sendTokenResponse(response, newAccessToken);
+        // 리프레쉬 토큰은 HTTP 쿠키에 저장
+        addCookie(response, "Refresh-Token", newRefreshToken, jwtUtil.getRefreshTokenExpiry());
+
+        return buildRedirectUrl(targetUrl, consumerId, "main");
     }
 
     /**
@@ -173,11 +186,15 @@ public class ConsumerService {
         log.info("프로필 업데이트 완료: consumerId={}, newProfileUrl={}", consumer.getId(), newProfileUrl);
     }
 
+    // 토큰을 응답 헤더에 추가하는 메서드
+    private void sendTokenResponse(HttpServletResponse response, String accessToken) {
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.addHeader("Access-Control-Expose-Headers", "Authorization");
+    }
+
     // ✅ URL 생성 메서드 분리
-    private String buildRedirectUrl(String targetUrl, String accessToken, String refreshToken, Long consumerId, String nextPage) {
+    private String buildRedirectUrl(String targetUrl, Long consumerId, String nextPage) {
         return UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("access-token", accessToken)
-                .queryParam("refresh-token", refreshToken)
                 .queryParam("consumer-id", consumerId)
                 .queryParam("next-page", nextPage)
                 .build().toUriString();
@@ -185,19 +202,22 @@ public class ConsumerService {
 
     // 로그아웃 처리 로직
     @Transactional
-    public void logoutUser() {
+    public void logoutUser(HttpServletRequest request, HttpServletResponse response) {
         Long consumerId = Long.valueOf(securityUtil.getConsumer().getId());
         log.info("logoutUser: "+consumerId);
 
         redisJwtRepository.deleteRefreshToken(consumerId);
         redisJwtRepository.deleteKakaoAccessToken(consumerId);
+
+        // 리프레쉬 토큰 쿠키 삭제 (액세스 토큰은 헤더로 전달되었으므로 별도 쿠키 삭제 필요 없음)
+        deleteCookie(request, response, "Refresh-Token");
     }
 
     /**
      * 회원탈퇴 처리 로직
      */
     @Transactional
-    public String handleUnlink(OAuth2UserPrincipal principal, String targetUrl) {
+    public String handleUnlink(OAuth2UserPrincipal principal, String targetUrl, HttpServletRequest request, HttpServletResponse response) {
         String socialId = principal.getUserInfo().getId();
         String accessToken = principal.getUserInfo().getAccessToken();
         OAuth2Provider provider = principal.getUserInfo().getProvider();
@@ -215,6 +235,9 @@ public class ConsumerService {
 
         // 사용자 논리 삭제
         withdrawConsumer(consumerId);
+
+        // 쿠키 삭제
+        deleteCookie(request, response, "Refresh-Token");
 
         log.info("회원탈퇴 완료: consumerId={}", consumerId);
 

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -160,18 +160,11 @@ public class ConsumerService {
         String newRefreshToken = jwtUtil.createRefreshToken(consumerId.toString());
 
         redisJwtRepository.saveRefreshToken(consumerId, newRefreshToken);
-        log.info("새로운 Access 및 Refresh Token 발급: consumerId={}, accessToken={}, refreshToken={}",
-                consumerId, newAccessToken, newRefreshToken);
+        redisJwtRepository.saveKakaoAccessToken(consumerId, principal.getUserInfo().getAccessToken());
+        log.info("새로운 Access 및 Refresh Token 발급: consumerId={}",
+                consumerId);
 
         return buildRedirectUrl(targetUrl, newAccessToken, consumerId);
-    }
-
-    /**
-     * 🔹 프로필이 변경되었는지 확인
-     */
-    public boolean isProfileChanged(Consumer consumer, OAuth2UserPrincipal principal) {
-        String newProfileUrl = principal.getUserInfo().getProfileImageUrl();
-        return !newProfileUrl.equals(consumer.getProfileImageUrl());
     }
 
     /**
@@ -193,30 +186,12 @@ public class ConsumerService {
                 .build().toUriString();
     }
 
-    /**
-     * 로그아웃 처리 로직
-     */
+    // 로그아웃 처리 로직
     @Transactional
     public void logoutUser() {
         Long consumerId = Long.valueOf(securityUtil.getConsumer().getId());
-        String kakaoAccessToken = redisJwtRepository.getKakaoAccessToken(consumerId);
         log.info("logoutUser: "+consumerId);
-        log.info("kakaoAccessToken: "+kakaoAccessToken);
 
-        // 1. 카카오 로그아웃 API 호출  전체 삭제인지?
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + kakaoAccessToken);
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-
-        ResponseEntity<String> response = restTemplate.postForEntity("https://kapi.kakao.com/v1/user/logout", entity, String.class);
-
-        if (!response.getStatusCode().is2xxSuccessful()) {
-            // 에러 처리
-            throw new RuntimeException("Failed to logout from Kakao");
-        }
-
-        // 2. 로컬 로그아웃 처리 : 토큰 삭제
-        // 레디스에서 해당 사용자의 리프레시 토큰 및 카카오 액세스 토큰 삭제
         redisJwtRepository.deleteRefreshToken(consumerId);
         redisJwtRepository.deleteKakaoAccessToken(consumerId);
     }

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -216,6 +216,7 @@ public class ConsumerService {
     /**
      * 로그아웃 처리 로직
      */
+    @Transactional
     public void logoutUser() {
         Long consumerId = Long.valueOf(securityUtil.getConsumer().getId());
         String kakaoAccessToken = redisJwtRepository.getKakaoAccessToken(consumerId);
@@ -244,6 +245,7 @@ public class ConsumerService {
     /**
      * 회원탈퇴 처리 로직
      */
+    @Transactional
     public String handleUnlink(OAuth2UserPrincipal principal, String targetUrl) {
         String socialId = principal.getUserInfo().getId();
         String accessToken = principal.getUserInfo().getAccessToken();

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -51,21 +51,6 @@ public class ConsumerService {
     private final JwtUtil jwtUtil;
     private final OAuth2UserUnlinkManager oAuth2UserUnlinkManager;
 
-
-    // 회원가입
-    @Transactional
-    public Long saveOAuth2User(OAuth2UserPrincipal principal) {
-        Consumer consumer = Consumer.builder()
-                .socialId(principal.getUserInfo().getId())
-                .email(principal.getUserInfo().getEmail())
-                .name(principal.getUserInfo().getName())
-                .profileImageUrl(principal.getUserInfo().getProfileImageUrl())
-                // 필요한 다른 필드 설정
-                .build();
-
-        return consumerRepository.save(consumer).getId();
-    }
-
     // socialId로 회원 찾기.
     public Optional<Consumer> findBySocialId(String socialId) {
         return consumerRepository.findBySocialIdAndDeletedAtIsNull(socialId);
@@ -110,7 +95,6 @@ public class ConsumerService {
      * - 회원 정보가 존재하지 않으면 회원가입 처리
      * - 존재하면 로그인 처리
      */
-    @Transactional // todo : 임시방편
     public String handleLoginOrRegister(OAuth2UserPrincipal principal, String targetUrl) {
         String socialId = principal.getUserInfo().getId();
         Optional<Consumer> consumerOptional = findBySocialId(socialId);
@@ -127,7 +111,8 @@ public class ConsumerService {
     /**
      * 회원가입 처리 로직
      */
-    private String registerUser(OAuth2UserPrincipal principal, String targetUrl) {
+    @Transactional
+    public String registerUser(OAuth2UserPrincipal principal, String targetUrl) {
         Long consumerId = saveOAuth2User(principal);
         log.info("회원가입 완료: consumerId={}", consumerId);
 
@@ -149,23 +134,78 @@ public class ConsumerService {
                 .build().toUriString();
     }
 
+    // 회원가입
+    private Long saveOAuth2User(OAuth2UserPrincipal principal) {
+        Consumer consumer = Consumer.builder()
+                .socialId(principal.getUserInfo().getId())
+                .email(principal.getUserInfo().getEmail())
+                .name(principal.getUserInfo().getName())
+                .profileImageUrl(principal.getUserInfo().getProfileImageUrl())
+                // 필요한 다른 필드 설정
+                .build();
+
+        return consumerRepository.save(consumer).getId();
+    }
+
     /**
      * 로그인 처리 로직
      */
-    private String loginUser(OAuth2UserPrincipal principal, Consumer consumer, String targetUrl) {
+    @Transactional
+    public String loginUser(OAuth2UserPrincipal principal, Consumer consumer, String targetUrl) {
         Long consumerId = consumer.getId();
 
-        // 프로필 업데이트
-        updateProfileIfChanged(consumer, principal);
+        // 프로필 변경이 필요할 때만 update 실행
+        if (isProfileChanged(consumer, principal)) {
+            updateProfile(consumer, principal);
+        }
 
-        // 토큰 생성 및 저장
+        // ✅ 기존 Access Token 확인 (유효하면 재사용)
+        String existingAccessToken = redisJwtRepository.getAccessToken(consumerId);
+        if (existingAccessToken != null && jwtUtil.validateAccessToken(existingAccessToken)) {
+            log.info("기존 토큰 재사용: consumerId={}, accessToken={}", consumerId, existingAccessToken);
+            return buildRedirectUrl(targetUrl, existingAccessToken, consumerId);
+        }
+
+        // ✅ 기존 Refresh Token 확인
+        String existingRefreshToken = redisJwtRepository.getRefreshToken(consumerId);
+        if (existingRefreshToken != null && jwtUtil.validateRefreshToken(existingRefreshToken)) {
+            String newAccessToken = jwtUtil.createAccessToken(consumerId.toString());
+            redisJwtRepository.saveAccessToken(consumerId, newAccessToken);
+            log.info("새로운 Access Token 발급: consumerId={}", consumerId);
+            return buildRedirectUrl(targetUrl, newAccessToken, consumerId);
+        }
+
+        // 🔥 Access Token과 Refresh Token 모두 만료 → 새로 발급
         String accessToken = jwtUtil.createAccessToken(consumerId.toString());
+        String refreshToken = jwtUtil.createRefreshToken(consumerId.toString());
         redisJwtRepository.saveAccessToken(consumerId, accessToken);
+        redisJwtRepository.saveRefreshToken(consumerId, refreshToken);
         redisJwtRepository.saveKakaoAccessToken(consumerId, principal.getUserInfo().getAccessToken());
 
-        log.info("로그인 완료: consumerId={}", consumerId);
+        log.info("Access Token & Refresh Token 새로 발급: consumerId={}", consumerId);
+        return buildRedirectUrl(targetUrl, accessToken, consumerId);
+    }
 
-        // 리다이렉션 URL 생성
+    /**
+     * 🔹 프로필이 변경되었는지 확인
+     */
+    public boolean isProfileChanged(Consumer consumer, OAuth2UserPrincipal principal) {
+        String newProfileUrl = principal.getUserInfo().getProfileImageUrl();
+        return !newProfileUrl.equals(consumer.getProfileImageUrl());
+    }
+
+    /**
+     * 🔹 프로필 변경이 필요한 경우에만 실행되는 트랜잭션
+     */
+    private void updateProfile(Consumer consumer, OAuth2UserPrincipal principal) {
+        String newProfileUrl = principal.getUserInfo().getProfileImageUrl();
+        consumer.updateProfileImageUrl(newProfileUrl);
+        consumerRepository.save(consumer);
+        log.info("프로필 업데이트 완료: consumerId={}, newProfileUrl={}", consumer.getId(), newProfileUrl);
+    }
+
+    // ✅ URL 생성 메서드 분리
+    private String buildRedirectUrl(String targetUrl, String accessToken, Long consumerId) {
         return UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("access-token", accessToken)
                 .queryParam("consumer-id", consumerId)
@@ -238,18 +278,6 @@ public class ConsumerService {
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         log.info("{} 사용자의 추가 정보 기입",consumerId);
         consumer.updateInfo(putConsumerInfoRequestDto);
-    }
-
-    /**
-     * 프로필 업데이트 메서드
-     */
-    private void updateProfileIfChanged(Consumer consumer, OAuth2UserPrincipal principal) {
-        String newProfileUrl = principal.getUserInfo().getProfileImageUrl();
-        if (!newProfileUrl.equals(consumer.getProfileImageUrl())) {
-            consumer.updateProfileImageUrl(newProfileUrl);
-            consumerRepository.save(consumer);
-            log.info("프로필 업데이트 완료: consumerId={}, newProfileUrl={}", consumer.getId(), newProfileUrl);
-        }
     }
 
     public Boolean isConsumerInProgressOrAttendanceFunding() {


### PR DESCRIPTION
<br/>

## 반영 브랜치

- refactor-loginTransaction -> main

<br/>

## 🔎 작업 내용

🔹 로그인 트랜잭션 최적화 • 서비스 클래스에 @Transactional(readOnly = true) 설정 적용, 데이터베이스 변경이 필요한 경우에만 @Transactional 적용
• Refresh Token 갱신 로직 개선: Access Token과 함께 항상 새로운 Refresh Token을 발급하도록 변경

🔹 JWT Authorization 필터 개선 • Access Token이 만료된 경우, http쿠키와 Redis에서 Refresh Token을 확인하여 자동으로 갱신
• 새로 발급된 Access Token을 SecurityContext에 반영하고 응답 헤더에도 추가
• Access Token이 유효한 경우 기존 방식대로 SecurityContext에 저장

🔹 로그인 로직 개선 • 로그인 시 매번 새로운 Access Token을 발급하도록 변경 (기존 Access Token 재사용 문제 해결)
• 로그인 시마다 새로운 Access Token과 Refresh Token을 발급하여 일관성 유지
• 쿼리 파라미터로 토큰을 전달하는 방식으로 변경하여, 요청이 보다 유연하게 처리되도록 개선

🔹 카카오 로그아웃 처리 개선
• 카카오 로그아웃 API 호출을 제거하고, 백엔드에서 관리하는 Refresh Token만 삭제하는 방식으로 수정

🔹 CORS 설정 적용 • Cross-Origin Resource Sharing (CORS) 설정 적용하여 외부에서 API 호출 시 발생할 수 있는 문제 해결
 • webConfig 파일 삭제 후 securityConfig 파일 내부에 작성
<br/>

## 🚩 참고 사항
	• 프론트 측 코드 변경 필요
	   - 모든 axios 요청에 쿠키 포함
	   - header로 오는 액세스 토큰 저장

<br/>
