### PR TITLE
[Chore] aop를 통한 service 매서드 실행 시간 측정 로깅

### DIFF
--- a/BE/src/main/java/com/d201/fundingift/_common/aop/ExecutionTimeAspect.java
+++ b/BE/src/main/java/com/d201/fundingift/_common/aop/ExecutionTimeAspect.java
@@ -1,0 +1,34 @@
+package com.d201.fundingift._common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class ExecutionTimeAspect {
+    @Around("execution(* com..fundingift..service.*.*(..))")
+    public Object logServiceMethodExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        return logExecutionTime(joinPoint, "\u001B[34m");
+    }
+
+    private Object logExecutionTime(ProceedingJoinPoint joinPoint, String color) throws Throwable {
+
+        long startTime = System.currentTimeMillis();
+        log.info("{}[{}.{}] start", color, joinPoint.getTarget().getClass().getSimpleName(), joinPoint.getSignature().getName());
+
+        Object result = joinPoint.proceed();
+
+        long endTime = System.currentTimeMillis();
+        long executionTime = endTime - startTime;
+        log.info("{}[{}.{}] end, 실행 시간: {}ms", color,
+                joinPoint.getTarget().getClass().getSimpleName(),
+                joinPoint.getSignature().getName(), executionTime);
+
+        return result;
+    }
+}


### PR DESCRIPTION
## 반영 브랜치

- feat-checkingTime -> main

<br/>

## 🔎 작업 내용

- Spring AOP를 이용해서 service 매서드 실행 시간 측정 로깅 구현
- 로깅 정보
  - [service 클래스명, 실행 메서드명] start 
  - [service 클래스명, 실행 메서드명] end, 실행 시간: ms

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/ac4ca5f8-9f38-4d7b-9332-6751b7cd423f" />
<img width="1325" alt="image" src="https://github.com/user-attachments/assets/ac0c2da7-53be-4e4b-9a1c-da86e4df98fb" />


<br/>

## 🚩 참고 사항

- 서비스 로직 속도 개선에 이용하세요.
- 전체적인 성능 테스트는 nGrinder로 할 예정입니다.

<br/>
