### PR TITLE
[Refactor] funding post test 코드 개선

### DIFF
--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
       ddl-auto: update
 
   profiles:
-    include: local
+    include: secret
 
   security:
     oauth2:

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -17,12 +17,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    properties:
-      hibernate:
-        format_sql: true
-        use_sql_comments: true
+
   profiles:
-    include: secret
+    include: local
 
   security:
     oauth2:
@@ -39,7 +36,6 @@ spring:
               - account_email
               - friends
 
-            # redirect-uri: "http://localhost:8081/{action}/oauth2/code/{registrationId}" # 로컬 테스트 용
             redirect-uri: "${BASE_URL}/{action}/oauth2/code/{registrationId}" # 배포 테스트 용
             client-name: Kakao
         provider:

--- a/BE/src/test/java/com/d201/fundingift/medium/funding/service/FundingPostServiceTest.java
+++ b/BE/src/test/java/com/d201/fundingift/medium/funding/service/FundingPostServiceTest.java
@@ -3,23 +3,16 @@ package com.d201.fundingift.medium.funding.service;
 import com.d201.fundingift.consumer.entity.Consumer;
 import com.d201.fundingift.consumer.repository.ConsumerRepository;
 import com.d201.fundingift.funding.dto.request.PostFundingRequest;
-import com.d201.fundingift.funding.intrastructure.entity.AnniversaryCategory;
 import com.d201.fundingift.funding.intrastructure.entity.FundingEntity;
-import com.d201.fundingift.funding.intrastructure.repository.AnniversaryCategoryRepository;
 import com.d201.fundingift.funding.intrastructure.repository.FundingJPARepository;
 import com.d201.fundingift.funding.service.FundingPostService;
-import com.d201.fundingift.product.entity.Product;
-import com.d201.fundingift.product.entity.ProductOption;
-import com.d201.fundingift.product.entity.status.ProductOptionStatus;
-import com.d201.fundingift.product.entity.status.ProductStatus;
-import com.d201.fundingift.product.repository.ProductOptionRepository;
-import com.d201.fundingift.product.repository.ProductRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlGroup;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -28,6 +21,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @TestPropertySource("classpath:application-test.properties")
+@SqlGroup({
+        @Sql(value = "/sql/post-funding-test-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+        @Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+})
 public class FundingPostServiceTest {
 
     @Autowired
@@ -37,59 +34,12 @@ public class FundingPostServiceTest {
     private FundingJPARepository fundingRepository;
     @Autowired
     private ConsumerRepository consumerRepository;
-    @Autowired
-    private ProductRepository productRepository;
-    @Autowired
-    private ProductOptionRepository productOptionRepository;
-    @Autowired
-    private AnniversaryCategoryRepository anniversaryCategoryRepository;
-
-    private Consumer consumer;
-
-    @BeforeEach
-    void setUp() {
-        consumer = Consumer.builder()
-                .id(1L)
-                .socialId("1")
-                .email("test@test.com")
-                .name("아무개")
-                .profileImageUrl("test.jpg")
-                .phoneNumber("01033333333")
-                .birthyear("1997")
-                .birthday("0509")
-                .gender("male")
-                .build();
-        consumerRepository.save(consumer);
-
-        Product product = Product.builder()
-                .id(1L)
-                .name("상품1")
-                .price(50000)
-                .description("테스트용 상품입니다.")
-                .image("product1.jpg")
-                .reviewAvg(0.0)
-                .reviewCnt(0)
-                .status(ProductStatus.ACTIVE)
-                .build();
-        productRepository.save(product);
-
-        ProductOption productOption = ProductOption.builder()
-                .id(1L)
-                .name("상품1 옵션")
-                .price(0)
-                .status(ProductOptionStatus.ACTIVE)
-                .product(product)
-                .build();
-        productOptionRepository.save(productOption);
-
-        AnniversaryCategory anniversaryCategory = new AnniversaryCategory(1, "생일");
-        anniversaryCategoryRepository.save(anniversaryCategory);
-    }
 
     @Test
     public void 펀딩을_생성할_수_있다() {
         //given
         LocalDate now = LocalDate.now();
+        Consumer consumer = consumerRepository.findById(1L).orElseThrow(() -> new RuntimeException("1L인 유저가 없습니다."));
         PostFundingRequest postFundingRequest = PostFundingRequest.builder()
                 .productId(1L)
                 .productOptionId(1L)

--- a/BE/src/test/resources/sql/delete-all-data.sql
+++ b/BE/src/test/resources/sql/delete-all-data.sql
@@ -1,0 +1,5 @@
+delete from funding where 1;
+delete from anniversary_category where 1;
+delete from consumer where 1;
+delete from product_option where 1;
+delete from product where 1;

--- a/BE/src/test/resources/sql/post-funding-test-data.sql
+++ b/BE/src/test/resources/sql/post-funding-test-data.sql
@@ -1,0 +1,19 @@
+INSERT INTO consumer
+    (consumer_id, social_id, email, name, profile_image_url, phone_number, birthyear, birthday, gender, created_at, updated_at)
+VALUES
+    (1, '1', 'test@test.com', '아무개', 'test.jpg', '01033333333', '1997', '0509', 'male', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO product
+(product_id, name, price, description, image, review_avg, review_cnt, status, created_at, updated_at)
+VALUES
+    (1, '상품1', 50000, '테스트용 상품입니다.', 'product1.jpg', 0.0, 0, 'ACTIVE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO product_option
+(product_option_id, name, price, status, product_id, created_at, updated_at)
+VALUES
+    (1, '상품1 옵션', 0, 'ACTIVE', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+INSERT INTO anniversary_category
+    (anniversary_category_id, name)
+VALUES
+    (1, '생일');


### PR DESCRIPTION
## 반영 브랜치

- refactor-fundingPostTest -> main

<br/>

## 🔎 작업 내용

- `@SpringBootTest`를 통한 펀딩 생성 테스트에 필요한 더미 데이터 삽입 방법 변경
  - 필요한 더미 데이터: consumer, product, product_option, anniversary_category
  - 기존 방식: `@BeforeEach`를 통해 repository로 데이터 삽입
  - 바꾼 방식: `@Sql`을 통해 쿼리로 직접 삽입
  - 이유
    - 필요한 더미 데이터의 repository를 테스트할 필요가 없기 때문
    - 코드 가독성을 높이기 위해
    - 불필요한 `@Autowired` 삭제
- 테스트 메서드 종료시 디비 데이터 삭제 로직 추가
  -  `@Sql`을 통해 쿼리로 직접 삭제

<br/>

## 🚩 참고 사항
- `@Sql`을 통해 쿼리로 직접 삭제시 delete, truncate 고민
  - 현재 테이블간 의존성이 존재하기 때문에 truncate의 경우 외래키 제약 조건을 풀고, 데이터 초기화 후 다시 외래키 제약 조건을 걸어야 함. <br> + 현재 메서드별 삭제 데이터가 별로 없음.
  - 따라서 truncate보단 **delete**가 적절하다고 판단 했습니다.

- 참고 
  - [테스트 코드 작성중 데이터 삭제 방식 결정: delete VS truncate](https://kdozlo.tistory.com/80) 

<img width="529" alt="image" src="https://github.com/user-attachments/assets/3bbffcfe-3b30-40b2-85c2-efa7da5b1902" />


<br/>
