### PR TITLE
[Fix] 로그인 트랜잭션 및 프로필 업데이트 더티 체킹 적용

### DIFF
--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -99,6 +99,7 @@ public class ConsumerService {
      * - 회원 정보가 존재하지 않으면 회원가입 처리
      * - 존재하면 로그인 처리
      */
+    @Transactional
     public String handleLoginOrRegister(OAuth2UserPrincipal principal, String targetUrl, HttpServletResponse response) {
         String socialId = principal.getUserInfo().getId();
         Optional<Consumer> consumerOptional = findBySocialId(socialId);
@@ -115,7 +116,6 @@ public class ConsumerService {
     /**
      * 회원가입 처리 로직
      */
-    @Transactional
     public String registerUser(OAuth2UserPrincipal principal, String targetUrl, HttpServletResponse response) {
         Long consumerId = saveOAuth2User(principal);
         log.info("회원가입 완료: consumerId={}", consumerId);
@@ -154,7 +154,6 @@ public class ConsumerService {
     /**
      * 로그인 처리 로직
      */
-    @Transactional
     public String loginUser(OAuth2UserPrincipal principal, Consumer consumer, String targetUrl, HttpServletResponse response) {
         Long consumerId = consumer.getId();
 
@@ -282,7 +281,6 @@ public class ConsumerService {
     }
 
     // 회원탈퇴
-    @Transactional
     public void withdrawConsumer(Long consumerId){
         Consumer consumer = consumerRepository.findByIdAndDeletedAtIsNull(consumerId)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 소비자 ID 입니다"));

--- a/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
+++ b/BE/src/main/java/com/d201/fundingift/consumer/service/ConsumerService.java
@@ -180,9 +180,10 @@ public class ConsumerService {
      */
     private void updateProfile(Consumer consumer, OAuth2UserPrincipal principal) {
         String newProfileUrl = principal.getUserInfo().getProfileImageUrl();
-        consumer.updateProfileImageUrl(newProfileUrl);
-        consumerRepository.save(consumer);
-        log.info("프로필 업데이트 완료: consumerId={}, newProfileUrl={}", consumer.getId(), newProfileUrl);
+        if (!consumer.getProfileImageUrl().equals(newProfileUrl)) { // 변경 감지
+            consumer.updateProfileImageUrl(newProfileUrl);
+            log.info("프로필 업데이트 완료: consumerId={}, newProfileUrl={}", consumer.getId(), newProfileUrl);
+        }
     }
 
     // 토큰을 응답 헤더에 추가하는 메서드


### PR DESCRIPTION
## 반영 브랜치

- refactor-transaction -> main

<br/>

## 🔎 작업 내용

✅ 로그인 트랜잭션 수정
	•	@Transactional 어노테이션을 handleLoginOrRegister()에 추가하여 로그인/회원가입 과정이 하나의 트랜잭션에서 처리되도록 수정
	•	registerUser() 및 loginUser()에서 개별적으로 트랜잭션을 관리하지 않도록 변경

✅ 프로필 업데이트 더티 체킹 적용
	•	기존 updateProfile()에서 consumerRepository.save(consumer) 호출을 제거
	•	JPA의 변경 감지(Dirty Checking) 를 활용하여, 프로필 정보가 변경된 경우에만 업데이트하도록 수정
	
<br/>

## 🚩 참고 사항

	•	로그인/회원가입 과정에서 트랜잭션이 분리될 가능성이 있었던 문제 해결
	•	불필요한 save() 호출을 제거하여 불필요한 DB I/O 최소화

<br/>
